### PR TITLE
Replace optional parameters with @QueryMap

### DIFF
--- a/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
+++ b/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
@@ -40,12 +40,49 @@ import retrofit.http.QueryMap;
 public interface SpotifyService {
 
     /**
-     * Profiles *
+     * The maximum number of objects to return..
      */
+    public static final String LIMIT = "limit";
+
+    /**
+     * The index of the first playlist to return. Default: 0 (the first object).
+     * Use with limit to get the next set of objects (albums, playlists, etc).
+     */
+    public static final String OFFSET = "offset";
+
+    /**
+     * A comma-separated list of keywords that will be used to filter the response.
+     * Valid values are: {@code album}, {@code single}, {@code appears_on}, {@code compilation}
+     */
+    public static final String ALBUM_TYPE = "album_type";
+
+    /**
+     * The country: an ISO 3166-1 alpha-2 country code.
+     * Limit the response to one particular geographical market.
+     * Synonym to {@link #COUNTRY}
+     */
+    public static final String MARKET = "market";
+
+    /**
+     * Same as {@link #MARKET}
+     */
+    public static final String COUNTRY = "country";
+
+    /**
+     * The desired language, consisting of a lowercase ISO 639 language code
+     * * and an uppercase ISO 3166-1 alpha-2 country code, joined by an underscore.
+     * For example: es_MX, meaning "Spanish (Mexico)".
+     */
+    public static final String LOCALE = "locale";
+
+    /************
+     * Profiles *
+     ************/
 
     /**
      * Get the currently logged in user profile information.
      * The contents of the User object may differ depending on application's scope.
+     *
      * @param callback Callback method
      * @see <a href="https://developer.spotify.com/web-api/get-current-users-profile/">Get Current User's Profile</a>
      */
@@ -55,6 +92,7 @@ public interface SpotifyService {
     /**
      * Get the currently logged in user profile information.
      * The contents of the User object may differ depending on application's scope.
+     *
      * @return The current user
      * @see <a href="https://developer.spotify.com/web-api/get-current-users-profile/">Get Current User's Profile</a>
      */
@@ -64,7 +102,8 @@ public interface SpotifyService {
 
     /**
      * Get a user's public profile information.
-     * @param userId The user's User ID
+     *
+     * @param userId   The user's User ID
      * @param callback Callback method
      * @see <a href"https://developer.spotify.com/web-api/get-users-profile/">Get User's Public Profile</a>
      */
@@ -73,6 +112,7 @@ public interface SpotifyService {
 
     /**
      * Get a user's public profile information.
+     *
      * @param userId The user's User ID
      * @return The user's public profile information.
      * @see <a href"https://developer.spotify.com/web-api/get-users-profile/">Get User's Public Profile</a>
@@ -81,46 +121,129 @@ public interface SpotifyService {
     public User getUser(@Path("id") String userId);
 
 
-    /**
+    /*************
      * Playlists *
+     *************/
+
+    /**
+     * Get a list of the playlists owned or followed by a Spotify user.
+     *
+     * @param userId   The user's Spotify user ID.
+     * @param options  Optional parameters. For list of supported parameters see
+     *                 <a href="https://developer.spotify.com/web-api/get-list-users-playlists/">endpoint documentation</a>
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-list-users-playlists/">Get a List of a User’s Playlists</a>
      */
-
     @GET("/users/{id}/playlists")
-    public void getPlaylists(@Path("id") String userId, @Query("offset") int offset, @Query("limit") int limit, Callback<Pager<Playlist>> callback);
+    public void getPlaylists(@Path("id") String userId, @QueryMap Map<String, Object> options, Callback<Pager<Playlist>> callback);
 
+    /**
+     * Get a list of the playlists owned or followed by a Spotify user.
+     *
+     * @param userId  The user's Spotify user ID.
+     * @param options Optional parameters. For list of supported parameters see
+     *                <a href="https://developer.spotify.com/web-api/get-list-users-playlists/">endpoint documentation</a>
+     * @return List of user's playlists wrapped in a {@code Pager} object
+     * @see <a href="https://developer.spotify.com/web-api/get-list-users-playlists/">Get a List of a User’s Playlists</a>
+     */
     @GET("/users/{id}/playlists")
-    public Pager<Playlist> getPlaylists(@Path("id") String userId, @Query("offset") int offset, @Query("limit") int limit);
+    public Pager<Playlist> getPlaylists(@Path("id") String userId, @QueryMap Map<String, Object> options);
 
+    /**
+     * Get a list of the playlists owned or followed by a Spotify user.
+     *
+     * @param userId   The user's Spotify user ID.
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-list-users-playlists/">Get a List of a User’s Playlists</a>
+     */
     @GET("/users/{id}/playlists")
     public void getPlaylists(@Path("id") String userId, Callback<Pager<Playlist>> callback);
 
+    /**
+     * Get a list of the playlists owned or followed by a Spotify user.
+     *
+     * @param userId The user's Spotify user ID.
+     * @return List of user's playlists wrapped in a {@code Pager} object
+     * @see <a href="https://developer.spotify.com/web-api/get-list-users-playlists/">Get a List of a User’s Playlists</a>
+     */
     @GET("/users/{id}/playlists")
     public Pager<Playlist> getPlaylists(@Path("id") String userId);
 
 
+    /**
+     * Get a playlist owned by a Spotify user.
+     *
+     * @param userId     The user's Spotify user ID.
+     * @param playlistId The Spotify ID for the playlist.
+     * @param callback   Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-playlist/">Get a Playlist</a>
+     */
     @GET("/users/{user_id}/playlists/{playlist_id}")
     public void getPlaylist(@Path("user_id") String userId, @Path("playlist_id") String playlistId, Callback<Playlist> callback);
 
+    /**
+     * Get a playlist owned by a Spotify user.
+     *
+     * @param userId     The user's Spotify user ID.
+     * @param playlistId The Spotify ID for the playlist.
+     * @return Requested Playlist.
+     * @see <a href="https://developer.spotify.com/web-api/get-playlist/">Get a Playlist</a>
+     */
     @GET("/users/{user_id}/playlists/{playlist_id}")
     public Playlist getPlaylist(@Path("user_id") String userId, @Path("playlist_id") String playlistId);
 
 
+    /**
+     * Get full details of the tracks of a playlist owned by a Spotify user.
+     *
+     * @param userId     The user's Spotify user ID.
+     * @param playlistId The Spotify ID for the playlist.
+     * @param options    Optional parameters. For list of supported parameters see
+     *                   <a href="https://developer.spotify.com/web-api/get-playlists-tracks/">endpoint documentation</a>
+     * @param callback   Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-playlists-tracks/">Get a Playlist’s Tracks</a>
+     */
     @GET("/users/{user_id}/playlists/{playlist_id}/tracks")
-    public void getPlaylistTracks(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @Query("offset") int offset, @Query("limit") int limit, Callback<Pager<PlaylistTrack>> callback);
+    public void getPlaylistTracks(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @QueryMap Map<String, Object> options, Callback<Pager<PlaylistTrack>> callback);
 
+    /**
+     * Get full details of the tracks of a playlist owned by a Spotify user.
+     *
+     * @param userId     The user's Spotify user ID.
+     * @param playlistId The Spotify ID for the playlist.
+     * @param options    Optional parameters. For list of supported parameters see
+     *                   <a href="https://developer.spotify.com/web-api/get-playlists-tracks/">endpoint documentation</a>
+     * @see <a href="https://developer.spotify.com/web-api/get-playlists-tracks/">Get a Playlist’s Tracks</a>
+     */
     @GET("/users/{user_id}/playlists/{playlist_id}/tracks")
-    public Pager<PlaylistTrack> getPlaylistTracks(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @Query("offset") int offset, @Query("limit") int limit);
+    public Pager<PlaylistTrack> getPlaylistTracks(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @QueryMap Map<String, Object> options);
 
+    /**
+     * Get full details of the tracks of a playlist owned by a Spotify user.
+     *
+     * @param userId     The user's Spotify user ID.
+     * @param playlistId The Spotify ID for the playlist.
+     * @param callback   Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-playlists-tracks/">Get a Playlist’s Tracks</a>
+     */
     @GET("/users/{user_id}/playlists/{playlist_id}/tracks")
     public void getPlaylistTracks(@Path("user_id") String userId, @Path("playlist_id") String playlistId, Callback<Pager<PlaylistTrack>> callback);
 
+    /**
+     * Get full details of the tracks of a playlist owned by a Spotify user.
+     *
+     * @param userId     The user's Spotify user ID.
+     * @param playlistId The Spotify ID for the playlist.
+     * @see <a href="https://developer.spotify.com/web-api/get-playlists-tracks/">Get a Playlist’s Tracks</a>
+     */
     @GET("/users/{user_id}/playlists/{playlist_id}/tracks")
     public Pager<PlaylistTrack> getPlaylistTracks(@Path("user_id") String userId, @Path("playlist_id") String playlistId);
 
     /**
      * Create a playlist
-     * @param userId The playlist's owner's User ID
-     * @param body The body parameters
+     *
+     * @param userId   The playlist's owner's User ID
+     * @param body     The body parameters
      * @param callback Callback method
      * @return The created playlist
      * @see <a href="https://developer.spotify.com/web-api/create-playlist/">Create a Playlist</a>
@@ -130,7 +253,8 @@ public interface SpotifyService {
 
     /**
      * Create a playlist
-     * @param userId The playlist's owner's User ID
+     *
+     * @param userId  The playlist's owner's User ID
      * @param options The body parameters
      * @return The created playlist
      * @see <a href="https://developer.spotify.com/web-api/create-playlist/">Create a Playlist</a>
@@ -140,27 +264,29 @@ public interface SpotifyService {
 
     /**
      * Add tracks to a playlist
-     * @param userId The owner of the playlist
-     * @param playlistId The playlist's ID
+     *
+     * @param userId          The owner of the playlist
+     * @param playlistId      The playlist's ID
      * @param queryParameters Query parameters
-     * @param body JSON body
+     * @param body            JSON body
      * @return A snapshot ID (the version of the playlist)
      * @see <a href="https://developer.spotify.com/web-api/add-tracks-to-playlist/">Add Tracks to a Playlist</a>
      */
     @POST("/users/{user_id}/playlists/{playlist_id}/tracks")
-    public SnapshotId addTracksToPlaylist(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @QueryMap Map<String, String> queryParameters, @Body Map<String, Object> body);
+    public SnapshotId addTracksToPlaylist(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @QueryMap Map<String, Object> queryParameters, @Body Map<String, Object> body);
 
     /**
      * Add tracks to a playlist
-     * @param userId The owner of the playlist
-     * @param playlistId The playlist's Id
+     *
+     * @param userId          The owner of the playlist
+     * @param playlistId      The playlist's Id
      * @param queryParameters Query parameters
-     * @param body The body parameters
-     * @param callback Callback method
+     * @param body            The body parameters
+     * @param callback        Callback method
      * @see <a href="https://developer.spotify.com/web-api/add-tracks-to-playlist/">Add Tracks to a Playlist</a>
      */
     @POST("/users/{user_id}/playlists/{playlist_id}/tracks")
-    public void addTracksToPlaylist(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @QueryMap Map<String, String> queryParameters, @Body Map<String, Object> body, Callback<Pager<PlaylistTrack>> callback);
+    public void addTracksToPlaylist(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @QueryMap Map<String, Object> queryParameters, @Body Map<String, Object> body, Callback<Pager<PlaylistTrack>> callback);
 
 
     @DELETEWITHBODY("/users/{user_id}/playlists/{playlist_id}/tracks")
@@ -216,102 +342,254 @@ public interface SpotifyService {
     public Result unfollowPlaylist(@Path("user_id") String userId, @Path("playlist_id") String playlistId);
 
 
-    /**
+    /**********
      * Albums *
-     */
+     **********/
 
+    /**
+     * Get Spotify catalog information for a single album.
+     *
+     * @param albumId  The Spotify ID for the album.
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-album/">Get an Album</a>
+     */
     @GET("/albums/{id}")
     public void getAlbum(@Path("id") String albumId, Callback<Album> callback);
 
+    /**
+     * Get Spotify catalog information for a single album.
+     *
+     * @param albumId The Spotify ID for the album.
+     * @return Requested album information
+     * @see <a href="https://developer.spotify.com/web-api/get-album/">Get an Album</a>
+     */
     @GET("/albums/{id}")
     public Album getAlbum(@Path("id") String albumId);
 
-
+    /**
+     * Get Spotify catalog information for multiple albums identified by their Spotify IDs.
+     *
+     * @param albumIds A comma-separated list of the Spotify IDs for the albums
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-several-albums/">Get Several Albums</a>
+     */
     @GET("/albums")
     public void getAlbums(@Query("ids") String albumIds, Callback<Albums> callback);
 
+    /**
+     * Get Spotify catalog information for multiple albums identified by their Spotify IDs.
+     *
+     * @param albumIds A comma-separated list of the Spotify IDs for the albums
+     * @return Object whose key is "albums" and whose value is an array of album objects.
+     * @see <a href="https://developer.spotify.com/web-api/get-several-albums/">Get Several Albums</a>
+     */
     @GET("/albums")
     public Albums getAlbums(@Query("ids") String albumIds);
 
 
+    /**
+     * Get Spotify catalog information about an album’s tracks.
+     *
+     * @param albumId The Spotify ID for the album.
+     * @return List of simplified album objects wrapped in a Pager object
+     * @see <a href="https://developer.spotify.com/web-api/get-albums-tracks/">Get an Album’s Tracks</a>
+     */
     @GET("/albums/{id}/tracks")
     public Pager<Track> getAlbumTracks(@Path("id") String albumId);
 
+    /**
+     * Get Spotify catalog information about an album’s tracks.
+     *
+     * @param albumId The Spotify ID for the album.
+     * @see <a href="https://developer.spotify.com/web-api/get-albums-tracks/">Get an Album’s Tracks</a>
+     */
     @GET("/albums/{id}/tracks")
     public void getAlbumTracks(@Path("id") String albumId, Callback<Pager<Track>> callback);
 
+    /**
+     * Get Spotify catalog information about an album’s tracks.
+     *
+     * @param albumId  The Spotify ID for the album.
+     * @param options  Optional parameters. For list of supported parameters see
+     *                 <a href="https://developer.spotify.com/web-api/get-albums-tracks/">endpoint documentation</a>
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-albums-tracks/">Get an Album’s Tracks</a>
+     */
     @GET("/albums/{id}/tracks")
-    public void getAlbumTracks(@Path("id") String albumId, @Query("offset") int offset, @Query("limit") int limit, Callback<Pager<Track>> callback);
+    public void getAlbumTracks(@Path("id") String albumId, @QueryMap Map<String, Object> options, Callback<Pager<Track>> callback);
 
+    /**
+     * Get Spotify catalog information about an album’s tracks.
+     *
+     * @param albumId The Spotify ID for the album.
+     * @param options Optional parameters. For list of supported parameters see
+     *                <a href="https://developer.spotify.com/web-api/get-albums-tracks/">endpoint documentation</a>
+     * @return List of simplified album objects wrapped in a Pager object
+     * @see <a href="https://developer.spotify.com/web-api/get-albums-tracks/">Get an Album’s Tracks</a>
+     */
     @GET("/albums/{id}/tracks")
-    public Pager<Track> getAlbumTracks(@Path("id") String albumId, @Query("offset") int offset, @Query("limit") int limit);
+    public Pager<Track> getAlbumTracks(@Path("id") String albumId, @QueryMap Map<String, Object> options);
+
+
+    /***********
+     * Artists *
+     ***********/
 
 
     /**
-     * Artists *
+     * Get Spotify catalog information for a single artist identified by their unique Spotify ID.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-artist/">Get an Artist</a>
      */
-
-    @GET("/artists/{id}/albums")
-    public void getArtistAlbums(@Path("id") String artistId, @Query("offset") int offset, @Query("limit") int limit, Callback<Pager<Album>> callback);
-
-    @GET("/artists/{id}/albums")
-    public Pager<Album> getArtistAlbums(@Path("id") String artistId, @Query("offset") int offset, @Query("limit") int limit);
-
-    @GET("/artists/{id}/albums")
-    public void getArtistAlbums(@Path("id") String artistId, Callback<Pager<Album>> callback);
-
-    @GET("/artists/{id}/albums")
-    public Pager<Album> getArtistAlbums(@Path("id") String artistId);
-
-    @GET("/artists/{id}/albums")
-    public void getArtistAlbums(@Path("id") String artistId, @QueryMap Map<String, String> options, Callback<Pager<Album>> callback);
-
-    @GET("/artists/{id}/albums")
-    public Pager<Album> getArtistAlbums(@Path("id") String artistId, @QueryMap Map<String, String> options);
-
-
-    @GET("/artists/{id}/top-tracks")
-    public void getArtistTopTrack(@Path("id") String artistId, @Query("offset") int offset, @Query("limit") int limit, Callback<Pager<Track>> callback);
-
-    @GET("/artists/{id}/top-tracks")
-    public Pager<Track> getArtistTopTrack(@Path("id") String artistId, @Query("offset") int offset, @Query("limit") int limit);
-
-    @GET("/artists/{id}/top-tracks")
-    public void getArtistTopTrack(@Path("id") String artistId, Callback<Pager<Track>> callback);
-
-    @GET("/artists/{id}/top-tracks")
-    public Pager<Track> getArtistTopTrack(@Path("id") String artistId);
-
-
-    @GET("/artists/{id}/related-artists")
-    public void getRelatedArtists(@Path("id") String artistId, @Query("offset") int offset, @Query("limit") int limit, Callback<Pager<Artist>> callback);
-
-    @GET("/artists/{id}/related-artists")
-    public Pager<Artist> getRelatedArtists(@Path("id") String artistId, @Query("offset") int offset, @Query("limit") int limit);
-
-    @GET("/artists/{id}/related-artists")
-    public void getRelatedArtists(@Path("id") String artistId, Callback<Pager<Artist>> callback);
-
-    @GET("/artists/{id}/related-artists")
-    public Pager<Artist> getRelatedArtists(@Path("id") String artistId);
-
-
     @GET("/artists/{id}")
     public void getArtist(@Path("id") String artistId, Callback<Artist> callback);
 
+    /**
+     * Get Spotify catalog information for a single artist identified by their unique Spotify ID.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @return Requested artist information
+     * @see <a href="https://developer.spotify.com/web-api/get-artist/">Get an Artist</a>
+     */
     @GET("/artists/{id}")
     public Artist getArtist(@Path("id") String artistId);
 
 
+    /**
+     * Get Several Artists
+     *
+     * @param artistIds A comma-separated list of the Spotify IDs for the artists
+     * @param callback  Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-several-artists/">Get Several Artists</a>
+     */
     @GET("/artists")
     public void getArtists(@Query("ids") String artistIds, Callback<Artists> callback);
 
+    /**
+     * Get Several Artists
+     *
+     * @param artistIds A comma-separated list of the Spotify IDs for the artists
+     * @return An object whose key is "artists" and whose value is an array of artist objects.
+     * @see <a href="https://developer.spotify.com/web-api/get-several-artists/">Get Several Artists</a>
+     */
     @GET("/artists")
     public Artists getArtists(@Query("ids") String artistIds);
 
+    /**
+     * Get Spotify catalog information about an artist’s albums.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-artists-albums/">Get an Artist's Albums</a>
+     */
+    @GET("/artists/{id}/albums")
+    public void getArtistAlbums(@Path("id") String artistId, Callback<Pager<Album>> callback);
 
     /**
-     * Tracks *
+     * Get Spotify catalog information about an artist’s albums.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @return An array of simplified album objects wrapped in a paging object.
+     * @see <a href="https://developer.spotify.com/web-api/get-artists-albums/">Get an Artist's Albums</a>
+     */
+    @GET("/artists/{id}/albums")
+    public Pager<Album> getArtistAlbums(@Path("id") String artistId);
+
+    /**
+     * Get Spotify catalog information about an artist’s albums.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @param options  Optional parameters. For list of supported parameters see
+     *                 <a href="https://developer.spotify.com/web-api/get-artists-albums/">endpoint documentation</a>
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-artists-albums/">Get an Artist's Albums</a>
+     */
+    @GET("/artists/{id}/albums")
+    public void getArtistAlbums(@Path("id") String artistId, @QueryMap Map<String, Object> options, Callback<Pager<Album>> callback);
+
+    /**
+     * Get Spotify catalog information about an artist’s albums.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @param options  Optional parameters. For list of supported parameters see
+     *                 <a href="https://developer.spotify.com/web-api/get-artists-albums/">endpoint documentation</a>
+     * @return An array of simplified album objects wrapped in a paging object.
+     * @see <a href="https://developer.spotify.com/web-api/get-artists-albums/">Get an Artist's Albums</a>
+     */
+    @GET("/artists/{id}/albums")
+    public Pager<Album> getArtistAlbums(@Path("id") String artistId, @QueryMap Map<String, Object> options);
+
+
+    /**
+     * Get Spotify catalog information about an artist’s top tracks by country.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @param options  Optional parameters. For list of supported parameters see
+     *                 <a href="https://developer.spotify.com/web-api/get-artists-top-tracks/">endpoint documentation</a>
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-artists-top-tracks/">Get an Artist’s Top Tracks</a>
+     */
+    @GET("/artists/{id}/top-tracks")
+    public void getArtistTopTrack(@Path("id") String artistId, @QueryMap Map<String, Object> options, Callback<Pager<Track>> callback);
+
+    /**
+     * Get Spotify catalog information about an artist’s top tracks by country.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @param options  Optional parameters. For list of supported parameters see
+     *                 <a href="https://developer.spotify.com/web-api/get-artists-top-tracks/">endpoint documentation</a>
+     * @return An object whose key is "tracks" and whose value is an array of track objects.
+     * @see <a href="https://developer.spotify.com/web-api/get-artists-top-tracks/">Get an Artist’s Top Tracks</a>
+     */
+    @GET("/artists/{id}/top-tracks")
+    public Pager<Track> getArtistTopTrack(@Path("id") String artistId, @QueryMap Map<String, Object> options);
+
+    /**
+     * Get Spotify catalog information about an artist’s top tracks by country.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @param callback Callback method
+     * @see <a href="https://developer.spotify.com/web-api/get-artists-top-tracks/">Get an Artist’s Top Tracks</a>
+     */
+    @GET("/artists/{id}/top-tracks")
+    public void getArtistTopTrack(@Path("id") String artistId, Callback<Pager<Track>> callback);
+
+    /**
+     * Get Spotify catalog information about an artist’s top tracks by country.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @return An object whose key is "tracks" and whose value is an array of track objects.
+     * @see <a href="https://developer.spotify.com/web-api/get-artists-top-tracks/">Get an Artist’s Top Tracks</a>
+     */
+    @GET("/artists/{id}/top-tracks")
+    public Pager<Track> getArtistTopTrack(@Path("id") String artistId);
+
+
+    /**
+     * Get Spotify catalog information about artists similar to a given artist.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @param callback Callback method.
+     * @see <a href="https://developer.spotify.com/web-api/get-related-artists/">Get an Artist’s Related Artists</a>
+     */
+    @GET("/artists/{id}/related-artists")
+    public void getRelatedArtists(@Path("id") String artistId, Callback<Pager<Artist>> callback);
+
+    /**
+     * Get Spotify catalog information about artists similar to a given artist.
+     *
+     * @param artistId The Spotify ID for the artist.
+     * @return An object whose key is "artists" and whose value is an array of artist objects.
+     * @see <a href="https://developer.spotify.com/web-api/get-related-artists/">Get an Artist’s Related Artists</a>
+     */
+    @GET("/artists/{id}/related-artists")
+    public Pager<Artist> getRelatedArtists(@Path("id") String artistId);
+
+
+    /**
+     * Tracks
      */
 
     @GET("/tracks/{id}")
@@ -329,7 +607,7 @@ public interface SpotifyService {
 
 
     /**
-     * Browse *
+     * Browse
      */
 
     @GET("/browse/featured-playlists")
@@ -339,16 +617,10 @@ public interface SpotifyService {
     public FeaturedPlaylists getFeaturedPlaylists();
 
     @GET("/browse/featured-playlists")
-    public void getFeaturedPlaylists(@QueryMap Map<String, String> options, Callback<FeaturedPlaylists> callback);
+    public void getFeaturedPlaylists(@QueryMap Map<String, Object> options, Callback<FeaturedPlaylists> callback);
 
     @GET("/browse/featured-playlists")
-    public FeaturedPlaylists getFeaturedPlaylists(@QueryMap Map<String, String> options);
-
-    @GET("/browse/featured-playlists")
-    public void getFeaturedPlaylists(@QueryMap Map<String, String> options, @Query("offset") int offset, @Query("limit") int limit, Callback<FeaturedPlaylists> callback);
-
-    @GET("/browse/featured-playlists")
-    public FeaturedPlaylists getFeaturedPlaylists(@QueryMap Map<String, String> options, @Query("offset") int offset, @Query("limit") int limit);
+    public FeaturedPlaylists getFeaturedPlaylists(@QueryMap Map<String, Object> options);
 
 
     @GET("/browse/new-releases")
@@ -358,82 +630,83 @@ public interface SpotifyService {
     public NewReleases getNewReleases();
 
     @GET("/browse/new-releases")
-    public void getNewReleases(@Query("country") String country, Callback<NewReleases> callback);
+    public void getNewReleases(@QueryMap Map<String, Object> options, Callback<NewReleases> callback);
 
     @GET("/browse/new-releases")
-    public NewReleases getNewReleases(@Query("country") String country);
+    public NewReleases getNewReleases(@QueryMap Map<String, Object> options);
 
-    @GET("/browse/new-releases")
-    public void getNewReleases(@Query("country") String country, @Query("offset") int offset, @Query("limit") int limit, Callback<NewReleases> callback);
-
-    @GET("/browse/new-releases")
-    public NewReleases getNewReleases(@Query("country") String country, @Query("offset") int offset, @Query("limit") int limit);
 
     /**
      * Retrieve Spotify categories. Categories used to tag items in
      * Spotify (on, for example, the Spotify player’s “Browse” tab).
-     * @param options Optional parameters.
+     *
+     * @param options  Optional parameters.
      * @param callback Callback method.
      * @see <a href="https://developer.spotify.com/web-api/get-list-categories/">Get a List of Categories</a>
      */
     @GET("/browse/categories")
-    public void getCategories(@QueryMap Map<String, String> options, Callback<CategoriesPager> callback);
+    public void getCategories(@QueryMap Map<String, Object> options, Callback<CategoriesPager> callback);
 
     /**
      * Retrieve Spotify categories. Categories used to tag items in
      * Spotify (on, for example, the Spotify player’s “Browse” tab).
+     *
      * @param options Optional parameters.
      * @return A paging object containing categories.
      * @see <a href="https://developer.spotify.com/web-api/get-list-categories/">Get a List of Categories</a>
      */
     @GET("/browse/categories")
-    public CategoriesPager getCategories(@QueryMap Map<String, String> options);
+    public CategoriesPager getCategories(@QueryMap Map<String, Object> options);
 
 
     /**
      * Retrieve a Spotify category.
+     *
      * @param categoryId The category's ID.
-     * @param options Optional parameters.
-     * @param callback Callback method.
+     * @param options    Optional parameters.
+     * @param callback   Callback method.
      * @see <a href="https://developer.spotify.com/web-api/get-category/">Get a Spotify Category</a>
      */
     @GET("/browse/categories/{category_id}")
-    public void getCategory(@Path("category_id") String categoryId, @QueryMap Map<String, String> options, Callback<Category> callback);
+    public void getCategory(@Path("category_id") String categoryId, @QueryMap Map<String, Object> options, Callback<Category> callback);
 
     /**
      * Retrieve a Spotify category.
+     *
      * @param categoryId The category's ID.
-     * @param options Optional parameters.
+     * @param options    Optional parameters.
      * @return A Spotify category.
      * @see <a href="https://developer.spotify.com/web-api/get-category/">Get a Spotify Category</a>
      */
     @GET("/browse/categories/{category_id}")
-    public Category getCategory(@Path("category_id") String categoryId, @QueryMap Map<String, String> options);
+    public Category getCategory(@Path("category_id") String categoryId, @QueryMap Map<String, Object> options);
 
 
     /**
      * Retrieve playlists for a Spotify Category.
+     *
      * @param categoryId The category's ID.
-     * @param options Optional parameters.
-     * @param callback Callback method.
+     * @param options    Optional parameters.
+     * @param callback   Callback method.
      * @see <a href="https://developer.spotify.com/web-api/get-categorys-playlists/">Get playlists for a Spotify Category</a>
      */
     @GET("/browse/categories/{category_id}/playlists")
-    public void getPlaylistsForCategory(@Path("category_id") String categoryId, @QueryMap Map<String, String> options, Callback<PlaylistsPager> callback);
+    public void getPlaylistsForCategory(@Path("category_id") String categoryId, @QueryMap Map<String, Object> options, Callback<PlaylistsPager> callback);
 
     /**
      * Retrieve playlists for a Spotify Category.
+     *
      * @param categoryId The category's ID.
-     * @param options Optional parameters.
+     * @param options    Optional parameters.
      * @return Playlists for a Spotify Category.
      * @see <a href="https://developer.spotify.com/web-api/get-categorys-playlists/">Get playlists for a Spotify Category</a>
      */
     @GET("/browse/categories/{category_id}/playlists")
-    public PlaylistsPager getPlaylistsForCategory(@Path("category_id") String categoryId, @QueryMap Map<String, String> options);
+    public PlaylistsPager getPlaylistsForCategory(@Path("category_id") String categoryId, @QueryMap Map<String, Object> options);
 
 
     /**
-     * Library / Your Music *
+     * Library / Your Music
      */
 
     @GET("/me/tracks")
@@ -443,10 +716,10 @@ public interface SpotifyService {
     public Pager<SavedTrack> getMySavedTracks();
 
     @GET("/me/tracks")
-    public void getMySavedTracks(@Query("offset") int offset, @Query("limit") int limit, Callback<Pager<SavedTrack>> callback);
+    public void getMySavedTracks(@QueryMap Map<String, Object> options, Callback<Pager<SavedTrack>> callback);
 
     @GET("/me/tracks")
-    public Pager<SavedTrack> getMySavedTracks(@Query("offset") int offset, @Query("limit") int limit);
+    public Pager<SavedTrack> getMySavedTracks(@QueryMap Map<String, Object> options);
 
 
     @GET("/me/tracks/contains")
@@ -471,7 +744,7 @@ public interface SpotifyService {
 
 
     /**
-     * Follow *
+     * Follow
      */
 
     @PUT("/me/following?type=user")
@@ -528,7 +801,7 @@ public interface SpotifyService {
 
 
     /**
-     * Search *
+     * Search
      */
 
     @GET("/search?type=track")
@@ -538,22 +811,10 @@ public interface SpotifyService {
     public TracksPager searchTracks(@Query("q") String q);
 
     @GET("/search?type=track")
-    public void searchTracks(@Query("q") String q, @Query("market") String market, Callback<TracksPager> callback);
+    public void searchTracks(@Query("q") String q, @QueryMap Map<String, Object> options, Callback<TracksPager> callback);
 
     @GET("/search?type=track")
-    public TracksPager searchTracks(@Query("q") String q, @Query("market") String market);
-
-    @GET("/search?type=track")
-    public void searchTracks(@Query("q") String q, @Query("offset") int offset, @Query("limit") int limit, Callback<TracksPager> callback);
-
-    @GET("/search?type=track")
-    public TracksPager searchTracks(@Query("q") String q, @Query("offset") int offset, @Query("limit") int limit);
-
-    @GET("/search?type=track")
-    public void searchTracks(@Query("q") String q, @Query("market") String market, @Query("offset") int offset, @Query("limit") int limit, Callback<TracksPager> callback);
-
-    @GET("/search?type=track")
-    public TracksPager searchTracks(@Query("q") String q, @Query("market") String market, @Query("offset") int offset, @Query("limit") int limit);
+    public TracksPager searchTracks(@Query("q") String q, @QueryMap Map<String, Object> options);
 
 
     @GET("/search?type=artist")
@@ -563,22 +824,10 @@ public interface SpotifyService {
     public ArtistsPager searchArtists(@Query("q") String q);
 
     @GET("/search?type=artist")
-    public void searchArtists(@Query("q") String q, @Query("market") String market, Callback<ArtistsPager> callback);
+    public void searchArtists(@Query("q") String q, @QueryMap Map<String, Object> options, Callback<ArtistsPager> callback);
 
     @GET("/search?type=artist")
-    public ArtistsPager searchArtists(@Query("q") String q, @Query("market") String market);
-
-    @GET("/search?type=artist")
-    public void searchArtists(@Query("q") String q, @Query("offset") int offset, @Query("limit") int limit, Callback<ArtistsPager> callback);
-
-    @GET("/search?type=artist")
-    public ArtistsPager searchArtists(@Query("q") String q, @Query("offset") int offset, @Query("limit") int limit);
-
-    @GET("/search?type=artist")
-    public void searchArtists(@Query("q") String q, @Query("market") String market, @Query("offset") int offset, @Query("limit") int limit, Callback<ArtistsPager> callback);
-
-    @GET("/search?type=artist")
-    public ArtistsPager searchArtists(@Query("q") String q, @Query("market") String market, @Query("offset") int offset, @Query("limit") int limit);
+    public ArtistsPager searchArtists(@Query("q") String q, @QueryMap Map<String, Object> options);
 
 
     @GET("/search?type=album")
@@ -588,22 +837,10 @@ public interface SpotifyService {
     public AlbumsPager searchAlbums(@Query("q") String q);
 
     @GET("/search?type=album")
-    public void searchAlbums(@Query("q") String q, @Query("market") String market, Callback<AlbumsPager> callback);
+    public void searchAlbums(@Query("q") String q, @QueryMap Map<String, Object> options, Callback<AlbumsPager> callback);
 
     @GET("/search?type=album")
-    public AlbumsPager searchAlbums(@Query("q") String q, @Query("market") String market);
-
-    @GET("/search?type=album")
-    public void searchAlbums(@Query("q") String q, @Query("offset") int offset, @Query("limit") int limit, Callback<AlbumsPager> callback);
-
-    @GET("/search?type=album")
-    public AlbumsPager searchAlbums(@Query("q") String q, @Query("offset") int offset, @Query("limit") int limit);
-
-    @GET("/search?type=album")
-    public void searchAlbums(@Query("q") String q, @Query("market") String market, @Query("offset") int offset, @Query("limit") int limit, Callback<AlbumsPager> callback);
-
-    @GET("/search?type=album")
-    public AlbumsPager searchAlbums(@Query("q") String q, @Query("market") String market, @Query("offset") int offset, @Query("limit") int limit);
+    public AlbumsPager searchAlbums(@Query("q") String q, @QueryMap Map<String, Object> options);
 
 
     @GET("/search?type=playlist")
@@ -613,20 +850,8 @@ public interface SpotifyService {
     public PlaylistsPager searchPlaylists(@Query("q") String q);
 
     @GET("/search?type=playlist")
-    public void searchPlaylists(@Query("q") String q, @Query("market") String market, Callback<PlaylistsPager> callback);
+    public void searchPlaylists(@Query("q") String q, @QueryMap Map<String, Object> options, Callback<PlaylistsPager> callback);
 
     @GET("/search?type=playlist")
-    public PlaylistsPager searchPlaylists(@Query("q") String q, @Query("market") String market);
-
-    @GET("/search?type=playlist")
-    public void searchPlaylists(@Query("q") String q, @Query("offset") int offset, @Query("limit") int limit, Callback<PlaylistsPager> callback);
-
-    @GET("/search?type=playlist")
-    public PlaylistsPager searchPlaylists(@Query("q") String q, @Query("offset") int offset, @Query("limit") int limit);
-
-    @GET("/search?type=playlist")
-    public void searchPlaylists(@Query("q") String q, @Query("market") String market, @Query("offset") int offset, @Query("limit") int limit, Callback<PlaylistsPager> callback);
-
-    @GET("/search?type=playlist")
-    public PlaylistsPager searchPlaylists(@Query("q") String q, @Query("market") String market, @Query("offset") int offset, @Query("limit") int limit);
+    public PlaylistsPager searchPlaylists(@Query("q") String q, @QueryMap Map<String, Object> options);
 }

--- a/src/test/java/kaaes/spotify/webapi/android/SpotifyServiceTest.java
+++ b/src/test/java/kaaes/spotify/webapi/android/SpotifyServiceTest.java
@@ -193,7 +193,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldGetArtistsAlbumsData() throws IOException {
-        Type modelType = new TypeToken<Pager<Album>>(){}.getType();
+        Type modelType = new TypeToken<Pager<Album>>() {
+        }.getType();
 
         String artistId = "1vCWHaC5f2uS3yhpwWbIA6";
         String body = TestUtils.readTestData("artist-album.json");
@@ -221,7 +222,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldGetPlaylistTracks() throws IOException {
-        Type modelType = new TypeToken<Pager<PlaylistTrack>>(){}.getType();
+        Type modelType = new TypeToken<Pager<PlaylistTrack>>() {
+        }.getType();
 
         String body = TestUtils.readTestData("playlist-tracks.json");
         Pager<PlaylistTrack> fixture = mGson.fromJson(body, modelType);
@@ -256,7 +258,11 @@ public class SpotifyServiceTest {
             }
         }))).thenReturn(response);
 
-        NewReleases newReleases = mSpotifyService.getNewReleases(countryId, 0, limit);
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(SpotifyService.COUNTRY, countryId);
+        options.put(SpotifyService.OFFSET, 0);
+        options.put(SpotifyService.LIMIT, limit);
+        NewReleases newReleases = mSpotifyService.getNewReleases(options);
 
         this.compareJSONWithoutNulls(body, newReleases);
     }
@@ -286,10 +292,13 @@ public class SpotifyServiceTest {
             }
         }))).thenReturn(response);
 
-        HashMap<String, String> map = new HashMap<String, String>();
-        map.put("country", countryId);
-        map.put("locale", locale);
-        FeaturedPlaylists featuredPlaylists = mSpotifyService.getFeaturedPlaylists(map, 0, limit);
+        HashMap<String, Object> map = new HashMap<String, Object>();
+        map.put(SpotifyService.COUNTRY, countryId);
+        map.put(SpotifyService.LOCALE, locale);
+        map.put(SpotifyService.OFFSET, 0);
+        map.put(SpotifyService.LIMIT, limit);
+
+        FeaturedPlaylists featuredPlaylists = mSpotifyService.getFeaturedPlaylists(map);
 
         this.compareJSONWithoutNulls(body, featuredPlaylists);
     }
@@ -320,7 +329,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldCheckFollowingUsers() throws IOException {
-        Type modelType = new TypeToken<List<Boolean>>(){}.getType();
+        Type modelType = new TypeToken<List<Boolean>>() {
+        }.getType();
         String body = TestUtils.readTestData("follow_is_following_users.json");
         List<Boolean> fixture = mGson.fromJson(body, modelType);
 
@@ -346,7 +356,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldCheckFollowingArtists() throws IOException {
-        Type modelType = new TypeToken<List<Boolean>>(){}.getType();
+        Type modelType = new TypeToken<List<Boolean>>() {
+        }.getType();
         String body = TestUtils.readTestData("follow_is_following_artists.json");
         List<Boolean> fixture = mGson.fromJson(body, modelType);
 
@@ -420,7 +431,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldGetPlaylistFollowersContains() throws IOException {
-        final Type modelType = new TypeToken<List<Boolean>>(){}.getType();
+        final Type modelType = new TypeToken<List<Boolean>>() {
+        }.getType();
         final String body = TestUtils.readTestData("playlist-followers-contains.json");
         final List<Boolean> fixture = mGson.fromJson(body, modelType);
 
@@ -429,15 +441,15 @@ public class SpotifyServiceTest {
         final String userIds = "thelinmichael,jmperezperez,kaees";
 
         when(mMockClient.execute(argThat(new ArgumentMatcher<Request>() {
-          @Override
-          public boolean matches(Object argument) {
-            try {
-              return ((Request) argument).getUrl()
-                  .contains("ids=" + URLEncoder.encode(userIds, "UTF-8"));
-            } catch (UnsupportedEncodingException e) {
-              return false;
+            @Override
+            public boolean matches(Object argument) {
+                try {
+                    return ((Request) argument).getUrl()
+                            .contains("ids=" + URLEncoder.encode(userIds, "UTF-8"));
+                } catch (UnsupportedEncodingException e) {
+                    return false;
+                }
             }
-          }
         }))).thenReturn(response);
 
         final String requestPlaylist = TestUtils.readTestData("playlist-response.json");
@@ -449,7 +461,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldGetCategories() throws Exception {
-        final Type modelType = new TypeToken<CategoriesPager>(){}.getType();
+        final Type modelType = new TypeToken<CategoriesPager>() {
+        }.getType();
         final String body = TestUtils.readTestData("get-categories.json");
         final CategoriesPager fixture = mGson.fromJson(body, modelType);
 
@@ -461,17 +474,20 @@ public class SpotifyServiceTest {
         final int limit = 2;
 
         when(mMockClient.execute(argThat(new ArgumentMatcher<Request>() {
-          @Override
-          public boolean matches(Object argument) {
-            return ((Request) argument).getUrl()
-              .contains(String.format("limit=%d&locale=%s&offset=%d&country=%s", limit, locale, offset, country));
-          }
+            @Override
+            public boolean matches(Object argument) {
+                String requestUrl = ((Request) argument).getUrl();
+                return requestUrl.contains(String.format("limit=%d", limit)) &&
+                        requestUrl.contains(String.format("offset=%d", offset)) &&
+                        requestUrl.contains(String.format("country=%s", country)) &&
+                        requestUrl.contains(String.format("locale=%s", locale));
+            }
         }))).thenReturn(response);
 
 
-        final Map<String, String> options = new HashMap<String, String>();
-        options.put("offset", String.valueOf(offset));
-        options.put("limit", String.valueOf(limit));
+        final Map<String, Object> options = new HashMap<String, Object>();
+        options.put("offset", offset);
+        options.put("limit", limit);
         options.put("country", country);
         options.put("locale", locale);
 
@@ -481,7 +497,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldGetCategory() throws Exception {
-        final Type modelType = new TypeToken<Category>(){}.getType();
+        final Type modelType = new TypeToken<Category>() {
+        }.getType();
         final String body = TestUtils.readTestData("category.json");
         final Category fixture = mGson.fromJson(body, modelType);
 
@@ -492,14 +509,16 @@ public class SpotifyServiceTest {
         final String locale = "sv_SE";
 
         when(mMockClient.execute(argThat(new ArgumentMatcher<Request>() {
-          @Override
-          public boolean matches(Object argument) {
-            return ((Request) argument).getUrl()
-                .contains(String.format("locale=%s&country=%s", locale, country));
-          }
+            @Override
+            public boolean matches(Object argument) {
+                String requestUrl = ((Request) argument).getUrl();
+                return requestUrl.contains(String.format("locale=%s", locale)) &&
+                        requestUrl.contains(String.format("country=%s", country));
+
+            }
         }))).thenReturn(response);
 
-        final Map<String, String> options = new HashMap<String, String>();
+        final Map<String, Object> options = new HashMap<String, Object>();
         options.put("country", country);
         options.put("locale", locale);
 
@@ -509,7 +528,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldGetPlaylistsForCategory() throws Exception {
-        final Type modelType = new TypeToken<PlaylistsPager>(){}.getType();
+        final Type modelType = new TypeToken<PlaylistsPager>() {
+        }.getType();
         final String body = TestUtils.readTestData("category-playlist.json");
         final PlaylistsPager fixture = mGson.fromJson(body, modelType);
 
@@ -521,17 +541,19 @@ public class SpotifyServiceTest {
         final int limit = 2;
 
         when(mMockClient.execute(argThat(new ArgumentMatcher<Request>() {
-          @Override
-          public boolean matches(Object argument) {
-            return ((Request) argument).getUrl()
-                .contains(String.format("limit=%d&offset=%d&country=%s", limit, offset, country));
-          }
+            @Override
+            public boolean matches(Object argument) {
+                String requestUrl = ((Request) argument).getUrl();
+                return requestUrl.contains(String.format("limit=%d", limit)) &&
+                        requestUrl.contains(String.format("offset=%d", offset)) &&
+                        requestUrl.contains(String.format("country=%s", country));
+            }
         }))).thenReturn(response);
 
-        final Map<String, String> options = new HashMap<String, String>();
+        final Map<String, Object> options = new HashMap<String, Object>();
         options.put("country", country);
-        options.put("offset", String.valueOf(offset));
-        options.put("limit", String.valueOf(limit));
+        options.put("offset", offset);
+        options.put("limit", limit);
 
         final PlaylistsPager result = mSpotifyService.getPlaylistsForCategory(categoryId, options);
         this.compareJSONWithoutNulls(body, result);
@@ -539,7 +561,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldCreatePlaylistUsingBodyMap() throws Exception {
-        final Type modelType = new TypeToken<Playlist>(){}.getType();
+        final Type modelType = new TypeToken<Playlist>() {
+        }.getType();
         final String body = TestUtils.readTestData("created-playlist.json");
         final Playlist fixture = mGson.fromJson(body, modelType);
 
@@ -566,11 +589,11 @@ public class SpotifyServiceTest {
 
 
                 final String expectedBody = String.format("{\"name\":\"%s\",\"public\":%b}",
-                    name, isPublic);
+                        name, isPublic);
 
                 return request.getUrl().endsWith(String.format("/users/%s/playlists", owner)) &&
-                       expectedBody.equals(body) &&
-                       "POST".equals(request.getMethod());
+                        JSONsContainSameData(expectedBody, body) &&
+                        "POST".equals(request.getMethod());
             }
         }))).thenReturn(response);
 
@@ -584,7 +607,8 @@ public class SpotifyServiceTest {
 
     @Test
     public void shouldAddTracksToPlaylist() throws Exception {
-        final Type modelType = new TypeToken<SnapshotId>(){}.getType();
+        final Type modelType = new TypeToken<SnapshotId>() {
+        }.getType();
         final String body = TestUtils.readTestData("snapshot-response.json");
         final SnapshotId fixture = mGson.fromJson(body, modelType);
 
@@ -612,11 +636,11 @@ public class SpotifyServiceTest {
                 }
 
                 final String expectedBody = String.format("{\"uris\":[\"%s\",\"%s\"]}",
-                                                          trackUri1, trackUri2);
+                        trackUri1, trackUri2);
                 return request.getUrl().endsWith(String.format("/users/%s/playlists/%s/tracks?position=%d",
-                                                               owner, playlistId, position)) &&
-                       expectedBody.equals(body) &&
-                       "POST".equals(request.getMethod());
+                        owner, playlistId, position)) &&
+                        JSONsContainSameData(expectedBody, body) &&
+                        "POST".equals(request.getMethod());
             }
         }))).thenReturn(response);
 
@@ -624,7 +648,7 @@ public class SpotifyServiceTest {
         final List<String> trackUris = Arrays.asList(trackUri1, trackUri2);
         options.put("uris", trackUris);
 
-        final Map<String, String> queryParameters = new HashMap<String, String>();
+        final Map<String, Object> queryParameters = new HashMap<String, Object>();
         queryParameters.put("position", String.valueOf(position));
 
         final SnapshotId result = mSpotifyService.addTracksToPlaylist(owner, playlistId, queryParameters, options);
@@ -654,5 +678,21 @@ public class SpotifyServiceTest {
         // with the one created from model. If they're different
         // it means the model is borked
         assertEquals(fixtureJsonElement, modelJsonElement);
+    }
+
+    /**
+     * Compares two JSON strings if they contain the same data even if the order
+     * of the keys differs.
+     *
+     * @param expected The JSON to test against
+     * @param actual   The tested JSON
+     * @return true if JSONs contain the same data, false otherwise.
+     */
+    private boolean JSONsContainSameData(String expected, String actual) {
+        JsonParser parser = new JsonParser();
+        JsonElement expectedJsonElement = parser.parse(expected);
+        JsonElement actualJsonElement = parser.parse(actual);
+
+        return expectedJsonElement.equals(actualJsonElement);
     }
 }


### PR DESCRIPTION
* Add links to the Web API documentation where optional
  parameters are documented.
* Use Map<String, Object> for easier numbers handling