### PR TITLE
Use encrypted Github token to push Javadoc to GH Pages on merge to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ build
 *.iws
 *.iml
 local.properties
-
-/doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
 language: java
+env:
+  global:
+    secure: QpUtfmGzlk2j90qBzSFo35ALFwqjS4phh94JJonIb0KyF3JfpN5z8i915/M6mFhCIiVvCJR7zJYjS5C60OL0RL+HkLkXXZ2WP5VPB6wUzzvIVax5Q+7z+VvhDkPHQwpYG8KkXq6eHqgJGSD/R9cRbc/KhQEhrxxrqQD5fw/Gpkc=
+
+script:
+- ./gradlew assemble check generateDocs --info --stacktrace
+
+after_success:
+- .utility/publish-javadoc.sh

--- a/.utility/publish-javadoc.sh
+++ b/.utility/publish-javadoc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ "$TRAVIS_REPO_SLUG" == "kaaes/spotify-web-api-android" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+
+  echo -e "Merged new code into master branch. Publishing Javadoc to GH Pages...\n"
+
+  cp -R build/docs $HOME/javadoc-latest
+
+  cd $HOME
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "travis-ci"
+  git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/kaaes/spotify-web-api-android gh-pages > /dev/null
+
+  cd gh-pages
+  git rm -rf ./javadoc
+  cp -Rf $HOME/javadoc-latest ./javadoc
+  git add -f .
+  git commit -m "Lastest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to gh-pages"
+  git push -fq origin gh-pages > /dev/null
+
+  echo -e "Published Javadoc to gh-pages.\n"
+
+fi

--- a/build.gradle
+++ b/build.gradle
@@ -43,11 +43,10 @@ task jarAll(type: Jar) {
 
 task generateDocs(type: Javadoc) {
     title = "Spotify Web API Android Client - API Reference"
-    destinationDir = file("./doc/")
+    destinationDir = file("./build/docs/")
     source = sourceSets.main.allJava
     classpath = configurations.compile
 
-    options.memberLevel = JavadocMemberLevel.PRIVATE
     options.links("http://docs.oracle.com/javase/7/docs/api/");
     options.links("http://square.github.io/retrofit/javadoc/");
 }


### PR DESCRIPTION
- Add encrypted access token with permission to push to repository.
- Push generated Javadoc to GH Pages branch on merge to master.
- Run Javadoc generation as part of Pull Request to ensure that format is OK, so that no Javadoc errors are found during merge to master.

Ping @kaaes 

:books: 