### PR TITLE
Add more descriptive error objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,38 @@ RestAdapter restAdapter = new RestAdapter.Builder()
 
 SpotifyService spotify = restAdapter.create(SpotifyService.class);
 ```
+## Error Handling
+
+When using Retrofit, errors are returned as [`RetrofitError`](http://square.github.io/retrofit/javadoc/retrofit/RetrofitError.html)
+objects. These objects, among others, contain HTTP status codes and their descriptions,
+for example `400 - Bad Request`.
+In many cases this will work well enough but in some cases Spotify Web API returns more detailed information,
+for example `400 - No search query`.
+
+To use the data returned in the response from the Web API `SpotifyCallback` object should be passed to the
+request method instead of regular Retrofit's `Callback`:
+```java
+spotify.getMySavedTracks(new SpotifyCallback<Pager<SavedTrack>>;() {
+    @Override
+    public void success(Pager<SavedTrack> savedTrackPager, Response response) {
+        // handle successful response
+    }
+
+    @Override
+    public void failure(SpotifyError error) {
+        // handle error
+    }
+});
+```
+For synchronous requests `RetrofitError` can be converted to `SpotifyError` if needed:
+```java
+try {
+    Pager<SavedTrack> mySavedTracks = spotify.getMySavedTracks();
+} catch (RetrofitError error) {
+    SpotifyError spotifyError = SpotifyError.fromRetrofitError(error);
+    // handle error
+}
+```
 
 ## Help
 

--- a/src/main/java/kaaes/spotify/webapi/android/SpotifyCallback.java
+++ b/src/main/java/kaaes/spotify/webapi/android/SpotifyCallback.java
@@ -4,8 +4,9 @@ import retrofit.Callback;
 import retrofit.RetrofitError;
 
 /**
- * A convenience object converting {@link retrofit.RetrofitError}s to {@link SpotifyError}s.
- * Pass this object to the request method to receive it in the error callback:
+ * A convenience object converting {@link retrofit.RetrofitError}s to {@link SpotifyError}s
+ * in the error callbacks.
+ *
  * {code <pre>
  * spotify.getMySavedTracks(new SpotifyCallback&lt;Pager&lt;SavedTrack&gt;&gt;() {
  *     {@literal @}Override

--- a/src/main/java/kaaes/spotify/webapi/android/SpotifyCallback.java
+++ b/src/main/java/kaaes/spotify/webapi/android/SpotifyCallback.java
@@ -1,0 +1,33 @@
+package kaaes.spotify.webapi.android;
+
+import retrofit.Callback;
+import retrofit.RetrofitError;
+
+/**
+ * A convenience object converting {@link retrofit.RetrofitError}s to {@link SpotifyError}s.
+ * Pass this object to the request method to receive it in the error callback:
+ * {code <pre>
+ * spotify.getMySavedTracks(new SpotifyCallback&lt;Pager&lt;SavedTrack&gt;&gt;() {
+ *     {@literal @}Override
+ *     public void success(Pager&lt;SavedTrack&gt; savedTrackPager, Response response) {
+ *         // handle successful response
+ *     }
+ *
+ *     {@literal @}Override
+ *     public void failure(SpotifyError error) {
+ *         // handle error
+ *     }
+ * });
+ * </pre>}
+ *
+ * @param <T> expected response type
+ * @see retrofit.Callback
+ */
+public abstract class SpotifyCallback<T> implements Callback<T> {
+    public abstract void failure(SpotifyError error);
+
+    @Override
+    public void failure(RetrofitError error) {
+        failure(SpotifyError.fromRetrofitError(error));
+    }
+}

--- a/src/main/java/kaaes/spotify/webapi/android/SpotifyError.java
+++ b/src/main/java/kaaes/spotify/webapi/android/SpotifyError.java
@@ -31,12 +31,12 @@ import retrofit.RetrofitError;
  * } catch (RetrofitError error) {
  *     SpotifyError spotifyError = SpotifyError.fromRetrofitError(error);
  * }
- * </pre>}* 
+ * </pre>}
  */
 public class SpotifyError extends Exception {
 
-    private RetrofitError mRetrofitError;
-    private ErrorDetails mErrorDetails;
+    private final RetrofitError mRetrofitError;
+    private final ErrorDetails mErrorDetails;
 
     public static SpotifyError fromRetrofitError(RetrofitError error) {
         ErrorResponse errorResponse = (ErrorResponse) error.getBodyAs(ErrorResponse.class);
@@ -50,7 +50,7 @@ public class SpotifyError extends Exception {
     }
 
     public SpotifyError(RetrofitError retrofitError, ErrorDetails errorDetails, String message) {
-        super(message);
+        super(message, retrofitError);
         mRetrofitError = retrofitError;
         mErrorDetails = errorDetails;
     }
@@ -58,6 +58,7 @@ public class SpotifyError extends Exception {
     public SpotifyError(RetrofitError retrofitError) {
         super(retrofitError);
         mRetrofitError = retrofitError;
+        mErrorDetails = null;
     }
 
     /**

--- a/src/main/java/kaaes/spotify/webapi/android/SpotifyError.java
+++ b/src/main/java/kaaes/spotify/webapi/android/SpotifyError.java
@@ -69,7 +69,7 @@ public class SpotifyError extends Exception {
     }
 
     /**
-     * @return true id there are {@link kaaes.spotify.webapi.android.models.ErrorDetails}
+     * @return true if there are {@link kaaes.spotify.webapi.android.models.ErrorDetails}
      * associated with this error. False otherwise.
      */
     public boolean hasErrorDetails() {
@@ -77,7 +77,7 @@ public class SpotifyError extends Exception {
     }
 
     /**
-     * @return Details returned from the Web API associated with this error idf present.
+     * @return Details returned from the Web API associated with this error if present.
      */
     public ErrorDetails getErrorDetails() {
         return mErrorDetails;

--- a/src/main/java/kaaes/spotify/webapi/android/SpotifyError.java
+++ b/src/main/java/kaaes/spotify/webapi/android/SpotifyError.java
@@ -1,0 +1,84 @@
+package kaaes.spotify.webapi.android;
+
+import kaaes.spotify.webapi.android.models.*;
+import retrofit.RetrofitError;
+
+/**
+ * This object wraps error responses from the Web API
+ * and provides access to details returned by the request that are usually more
+ * descriptive than default Retrofit error messages.
+ * <p>
+ * To use with asynchronous requests pass {@link SpotifyCallback}
+ * instead of {@link retrofit.Callback} when making the request:
+ * {code <pre>
+ * spotify.getMySavedTracks(new SpotifyCallback&lt;Pager&lt;SavedTrack&gt;&gt;() {
+ *     {@literal @}Override
+ *     public void success(Pager&lt;SavedTrack&gt; savedTrackPager, Response response) {
+ *         // handle successful response
+ *     }
+ *
+ *     {@literal @}Override
+ *     public void failure(SpotifyError error) {
+ *         // handle error
+ *     }
+ * });
+ * </pre>}
+ * <p>
+ * To use with synchronous requests:
+ * {@code <pre>
+ * try {
+ *     Pager&lt;SavedTrack&gt; mySavedTracks = spotify.getMySavedTracks();
+ * } catch (RetrofitError error) {
+ *     SpotifyError spotifyError = SpotifyError.fromRetrofitError(error);
+ * }
+ * </pre>}* 
+ */
+public class SpotifyError extends Exception {
+
+    private RetrofitError mRetrofitError;
+    private ErrorDetails mErrorDetails;
+
+    public static SpotifyError fromRetrofitError(RetrofitError error) {
+        ErrorResponse errorResponse = (ErrorResponse) error.getBodyAs(ErrorResponse.class);
+
+        if (errorResponse != null && errorResponse.error != null) {
+            String message = errorResponse.error.status + " " + errorResponse.error.message;
+            return new SpotifyError(error, errorResponse.error, message);
+        } else {
+            return new SpotifyError(error);
+        }
+    }
+
+    public SpotifyError(RetrofitError retrofitError, ErrorDetails errorDetails, String message) {
+        super(message);
+        mRetrofitError = retrofitError;
+        mErrorDetails = errorDetails;
+    }
+
+    public SpotifyError(RetrofitError retrofitError) {
+        super(retrofitError);
+        mRetrofitError = retrofitError;
+    }
+
+    /**
+     * @return the original {@link retrofit.RetrofitError} that was returned for this request.
+     */
+    public RetrofitError getRetrofitError() {
+        return mRetrofitError;
+    }
+
+    /**
+     * @return true id there are {@link kaaes.spotify.webapi.android.models.ErrorDetails}
+     * associated with this error. False otherwise.
+     */
+    public boolean hasErrorDetails() {
+        return mErrorDetails != null;
+    }
+
+    /**
+     * @return Details returned from the Web API associated with this error idf present.
+     */
+    public ErrorDetails getErrorDetails() {
+        return mErrorDetails;
+    }
+}

--- a/src/main/java/kaaes/spotify/webapi/android/models/ErrorDetails.java
+++ b/src/main/java/kaaes/spotify/webapi/android/models/ErrorDetails.java
@@ -1,0 +1,9 @@
+package kaaes.spotify.webapi.android.models;
+
+/**
+ * <a href="https://developer.spotify.com/web-api/object-model/#error-object">Error object model</a>
+ */
+public class ErrorDetails {
+    public int status;
+    public String message;
+}

--- a/src/main/java/kaaes/spotify/webapi/android/models/ErrorResponse.java
+++ b/src/main/java/kaaes/spotify/webapi/android/models/ErrorResponse.java
@@ -1,0 +1,5 @@
+package kaaes.spotify.webapi.android.models;
+
+public class ErrorResponse {
+    public ErrorDetails error;
+}

--- a/src/test/fixtures/error-unauthorized.json
+++ b/src/test/fixtures/error-unauthorized.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "status": 401,
+    "message": "The access token expired"
+  }
+}

--- a/src/test/java/kaaes/spotify/webapi/android/TestUtils.java
+++ b/src/test/java/kaaes/spotify/webapi/android/TestUtils.java
@@ -46,18 +46,23 @@ public class TestUtils {
         }
     }
 
+    public static <T> Response getResponseFromModel(int statusCode, T model, Class<T> modelClass) {
+        ResponseBody responseBody = new ResponseBody(gson.toJson(model, modelClass));
+        return createResponse(statusCode, responseBody);
+    }
+
     public static <T> Response getResponseFromModel(T model, Class<T> modelClass) {
         ResponseBody responseBody = new ResponseBody(gson.toJson(model, modelClass));
-        return createResponse(responseBody);
+        return createResponse(200, responseBody);
     }
 
     public static <T> Response getResponseFromModel(T model, Type modelType) {
         ResponseBody responseBody = new ResponseBody(gson.toJson(model, modelType));
-        return createResponse(responseBody);
+        return createResponse(200, responseBody);
     }
 
-    private static Response createResponse(ResponseBody responseBody) {
-        return new Response("", 200, "", new ArrayList<Header>(), responseBody);
+    private static Response createResponse(int statusCode, ResponseBody responseBody) {
+        return new Response("", statusCode, "", new ArrayList<Header>(), responseBody);
     }
 
     public static String readTestData(String fileName) throws IOException {


### PR DESCRIPTION
Reftrofit errors returned from the Web API are sometimes
too generic. This change adds SpotifyError that contains
status code and message returned.

RetrofitError: 403 Forbidden
SpotifyError: 403 Insufficient client scope

RetrofitError: 400 Bad Request
SpotifyError: 400 No search query