### PR TITLE
Removed setClient in RestAdapter's initialization

### DIFF
--- a/src/main/java/kaaes/spotify/webapi/android/SpotifyApi.java
+++ b/src/main/java/kaaes/spotify/webapi/android/SpotifyApi.java
@@ -52,7 +52,6 @@ public class SpotifyApi {
         Executor executor = Executors.newSingleThreadExecutor();
         RestAdapter restAdapter = new RestAdapter.Builder()
                 .setLogLevel(RestAdapter.LogLevel.BASIC)
-                .setClient(new OkClient(new OkHttpClient()))
                 .setExecutors(executor, executor)
                 .setEndpoint(SPOTIFY_WEB_API_ENDPOINT)
                 .setRequestInterceptor(new WebApiAuthenticator())


### PR DESCRIPTION
Since Retrofit can work without OkHttp, I think it would be better to let developers decide what client to use. If a developer wants to stick with OkHttp, it will suffice to add it to the dependencies and Retrofit will use that automatically, as per Retrofit documentation:

"INTEGRATION WITH OKHTTP
Retrofit will automatically use OkHttp (version 2.0 or newer) when it is present."
[reference: http://square.github.io/retrofit/]

In addition, this post of Jake Wharton gives a better understanding of the situation:
https://github.com/square/retrofit/issues/467#issuecomment-41492536

"The reason the method exists is so that you can customize an HTTP client and explicitly set it. If you want to control connection timeouts, install a disk cache, or use an esoteric HTTP client we don't have support for you can explicitly do so."

This is not the case for spotify-web-api-android, so the use of setClient is unnecessary.