### PR TITLE
Added is_local to PlaylistTrack

### DIFF
--- a/src/main/java/kaaes/spotify/webapi/android/models/PlaylistTrack.java
+++ b/src/main/java/kaaes/spotify/webapi/android/models/PlaylistTrack.java
@@ -7,4 +7,5 @@ public class PlaylistTrack {
     public String added_at;
     public UserSimple added_by;
     public Track track;
+    public Boolean is_local;
 }


### PR DESCRIPTION
Added `is_local` to `PlaylistTrack` to expose if the track is a local file or not as described in the [playlist track object](https://developer.spotify.com/web-api/object-model/#playlist-track-object) documentation.