### PR TITLE
Moved snapshot_id from Playlist to PlaylistBase

### DIFF
--- a/src/main/java/kaaes/spotify/webapi/android/models/Playlist.java
+++ b/src/main/java/kaaes/spotify/webapi/android/models/Playlist.java
@@ -6,6 +6,5 @@ package kaaes.spotify.webapi.android.models;
 public class Playlist extends PlaylistBase {
     public String description;
     public Followers followers;
-    public String snapshot_id;
     public Pager<PlaylistTrack> tracks;
 }

--- a/src/main/java/kaaes/spotify/webapi/android/models/PlaylistBase.java
+++ b/src/main/java/kaaes/spotify/webapi/android/models/PlaylistBase.java
@@ -19,6 +19,7 @@ public abstract class PlaylistBase {
     public UserSimple owner;
     @SerializedName("public")
     public Boolean is_public;
+    public String snapshot_id;
     public String type;
     public String uri;
 }


### PR DESCRIPTION
Fixes issue #69. 

Moved `snapshot_id` from `Playlist` to `PlaylistBase` to expose snapshot_id also in simplified playlist as described in the [documentation](https://developer.spotify.com/web-api/object-model/#playlist-object-simplified). 