### PR TITLE
Reverted Jacoco configuration only to be executed for debug builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ android {
     buildToolsVersion '22.0.1'
 
     buildTypes {
-        release {
+        debug {
             testCoverageEnabled = true
         }
     }


### PR DESCRIPTION
When migrating from JAR to AAR (PR #63), Jacoco has been enabled first for debug builds (27ec3a9d4092f7ca813d9a8f25e5ee8be59eaa50) and shortly after it has been switched to release builds (9115699c20977fcd131633a527d076308aed2e0d). This causes the `jacocoagent.jar` library to be included in the final AAR, introducing nearly 1000 extra methods and bumping the size from 23KB to 268KB.

This PR is aimed at fixing this behavior, thus enabling Jacoco only for debug builds.


