### PR TITLE
Change jcentral to mavenCentral in build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
ping @d-kunin 

Using jcentral causes problems with HTTPS when building mavenCentral doesn't have this problem