### PR TITLE
Use main thread executor for callbacks by default

### DIFF
--- a/src/main/java/kaaes/spotify/webapi/android/SpotifyApi.java
+++ b/src/main/java/kaaes/spotify/webapi/android/SpotifyApi.java
@@ -5,6 +5,7 @@ import java.util.concurrent.Executors;
 
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
+import retrofit.android.MainThreadExecutor;
 
 /**
  * Creates and configures a REST adapter for Spotify Web API.
@@ -74,7 +75,8 @@ public class SpotifyApi {
      */
     public SpotifyApi() {
         Executor httpExecutor = Executors.newSingleThreadExecutor();
-        mSpotifyService = init(httpExecutor, null);
+        MainThreadExecutor callbackExecutor = new MainThreadExecutor();
+        mSpotifyService = init(httpExecutor, callbackExecutor);
     }
 
     /**


### PR DESCRIPTION
ping @d-kunin 

[According to Retrofit docs](https://square.github.io/retrofit/javadoc/retrofit/RestAdapter.Builder.html#setExecutors-java.util.concurrent.Executor-java.util.concurrent.Executor-) passing null as executor for callbacks result in them being called on the same thread as the HTTP client but I think it makes more sense to run them by default on the main thread and override when needed
