### PR TITLE
Changed explicit in TrackSimple from boolean to Boolean

### DIFF
--- a/src/main/java/kaaes/spotify/webapi/android/models/TrackSimple.java
+++ b/src/main/java/kaaes/spotify/webapi/android/models/TrackSimple.java
@@ -10,7 +10,7 @@ public class TrackSimple {
     public LinkedTrack linked_from;
     public int disc_number;
     public long duration_ms;
-    public boolean explicit;
+    public Boolean explicit;
     public Map<String, String> external_urls;
     public String href;
     public String id;


### PR DESCRIPTION
With this fix if we exclude `explicit` from the list of returned fields it will be `null` instead `false`