### PR TITLE
Add Parcel functionality to PlaylistBase and derived classes

### DIFF
--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/Playlist.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/Playlist.java
@@ -18,15 +18,18 @@ public class Playlist extends PlaylistBase {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
         dest.writeString(this.description);
         dest.writeParcelable(this.followers, 0);
         dest.writeParcelable(this.tracks, 0);
     }
 
     public Playlist() {
+        super();
     }
 
     protected Playlist(Parcel in) {
+        super(in);
         this.description = in.readString();
         this.followers = in.readParcelable(Followers.class.getClassLoader());
         this.tracks = in.readParcelable(Pager.class.getClassLoader());

--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlaylistBase.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlaylistBase.java
@@ -1,9 +1,12 @@
 package kaaes.spotify.webapi.android.models;
 
+import android.os.Parcel;
 import android.os.Parcelable;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -24,4 +27,58 @@ public abstract class PlaylistBase implements Parcelable {
     public String snapshot_id;
     public String type;
     public String uri;
+
+    protected PlaylistBase() {
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeByte((byte) (collaborative ? 1 : 0));
+
+        dest.writeInt(external_urls.size());
+        for(Map.Entry<String, String> entry : external_urls.entrySet()) {
+            dest.writeString(entry.getKey());
+            dest.writeString(entry.getValue());
+        }
+
+        dest.writeString(href);
+        dest.writeString(id);
+        dest.writeList(images);
+        dest.writeString(name);
+        dest.writeParcelable(owner, flags);
+        dest.writeByte((byte) (is_public ? 1 : 0));
+        dest.writeString(snapshot_id);
+        dest.writeString(type);
+        dest.writeString(uri);
+    }
+
+    protected PlaylistBase(Parcel in) {
+        this.collaborative = in.readByte() != 0;
+
+        int size = in.readInt();
+        external_urls = new HashMap<>();
+        for(int i = 0; i < size; i++) {
+            String key = in.readString();
+            String val = in.readString();
+            this.external_urls.put(key, val);
+        }
+
+        this.href = in.readString();
+        this.id = in.readString();
+
+        images = new ArrayList<>();
+        in.readList(images, Image.class.getClassLoader());
+
+        this.name = in.readString();
+        this.owner = in.readParcelable(Image.class.getClassLoader());
+        this.is_public = in.readByte() != 0;
+        this.snapshot_id = in.readString();
+        this.type = in.readString();
+        this.uri = in.readString();
+    }
 }

--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlaylistBase.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlaylistBase.java
@@ -38,8 +38,7 @@ public abstract class PlaylistBase implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeByte((byte) (collaborative ? 1 : 0));
-
+        dest.writeByte((byte) (collaborative == null ? 0 : collaborative ? 1 : 0));
         dest.writeInt(external_urls.size());
         for(Map.Entry<String, String> entry : external_urls.entrySet()) {
             dest.writeString(entry.getKey());
@@ -51,7 +50,7 @@ public abstract class PlaylistBase implements Parcelable {
         dest.writeList(images);
         dest.writeString(name);
         dest.writeParcelable(owner, flags);
-        dest.writeByte((byte) (is_public ? 1 : 0));
+        dest.writeByte((byte) (is_public == null ? 1 : is_public ? 1 : 0));
         dest.writeString(snapshot_id);
         dest.writeString(type);
         dest.writeString(uri);

--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlaylistBase.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlaylistBase.java
@@ -38,46 +38,30 @@ public abstract class PlaylistBase implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeByte((byte) (collaborative == null ? 0 : collaborative ? 1 : 0));
-        dest.writeInt(external_urls.size());
-        for(Map.Entry<String, String> entry : external_urls.entrySet()) {
-            dest.writeString(entry.getKey());
-            dest.writeString(entry.getValue());
-        }
-
-        dest.writeString(href);
-        dest.writeString(id);
-        dest.writeList(images);
-        dest.writeString(name);
+        dest.writeValue(this.collaborative);
+        dest.writeMap(this.external_urls);
+        dest.writeValue(this.href);
+        dest.writeValue(this.id);
+        dest.writeTypedList(this.images);
+        dest.writeValue(this.name);
         dest.writeParcelable(owner, flags);
-        dest.writeByte((byte) (is_public == null ? 1 : is_public ? 1 : 0));
-        dest.writeString(snapshot_id);
-        dest.writeString(type);
-        dest.writeString(uri);
+        dest.writeValue(is_public);
+        dest.writeValue(snapshot_id);
+        dest.writeValue(type);
+        dest.writeValue(uri);
     }
 
     protected PlaylistBase(Parcel in) {
-        this.collaborative = in.readByte() != 0;
-
-        int size = in.readInt();
-        external_urls = new HashMap<>();
-        for(int i = 0; i < size; i++) {
-            String key = in.readString();
-            String val = in.readString();
-            this.external_urls.put(key, val);
-        }
-
-        this.href = in.readString();
-        this.id = in.readString();
-
-        images = new ArrayList<>();
-        in.readList(images, Image.class.getClassLoader());
-
-        this.name = in.readString();
-        this.owner = in.readParcelable(Image.class.getClassLoader());
-        this.is_public = in.readByte() != 0;
-        this.snapshot_id = in.readString();
-        this.type = in.readString();
-        this.uri = in.readString();
+        this.collaborative = (Boolean) in.readValue(Boolean.class.getClassLoader());
+        this.external_urls = in.readHashMap(Map.class.getClassLoader());
+        this.href = (String) in.readValue(String.class.getClassLoader());
+        this.id = (String) in.readValue(String.class.getClassLoader());
+        this.images = in.createTypedArrayList(Image.CREATOR);
+        this.name = (String) in.readValue(String.class.getClassLoader());
+        this.owner = in.readParcelable(UserPublic.class.getClassLoader());
+        this.is_public = (Boolean) in.readValue(Boolean.class.getClassLoader());
+        this.snapshot_id = (String) in.readValue(String.class.getClassLoader());
+        this.type = (String) in.readValue(String.class.getClassLoader());
+        this.uri = (String) in.readValue(String.class.getClassLoader());
     }
 }

--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlaylistSimple.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlaylistSimple.java
@@ -15,13 +15,16 @@ public class PlaylistSimple extends PlaylistBase {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
         dest.writeParcelable(this.tracks, flags);
     }
 
     public PlaylistSimple() {
+        super();
     }
 
     protected PlaylistSimple(Parcel in) {
+        super(in);
         this.tracks = in.readParcelable(PlaylistTracksInformation.class.getClassLoader());
     }
 


### PR DESCRIPTION
With this implemented, the derived classes (PlaylistSimple and Playlist) can be written and restored from a Parcel. This enables the ability to pass Playlist and PlaylistSimple objects between activities.