### PR TITLE
Prevent crash when response is malformed

### DIFF
--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyError.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyError.java
@@ -37,7 +37,13 @@ public class SpotifyError extends Exception {
     private final ErrorDetails mErrorDetails;
 
     public static SpotifyError fromRetrofitError(RetrofitError error) {
-        ErrorResponse errorResponse = (ErrorResponse) error.getBodyAs(ErrorResponse.class);
+        ErrorResponse errorResponse = null;
+
+        try {
+            errorResponse = (ErrorResponse) error.getBodyAs(ErrorResponse.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
 
         if (errorResponse != null && errorResponse.error != null) {
             String message = errorResponse.error.status + " " + errorResponse.error.message;


### PR DESCRIPTION
When the wrapper creates a `SpotifyError` it could crash if the response is malformed. 

This is due to the method `getBodyAs` of Retrofit because it could throw a `RuntimeException` when the conversion fails [[1]](https://github.com/square/retrofit/blob/2f4caa6f5df8e7f47a881266bbfc723f537b0b47/retrofit/src/main/java/retrofit/RetrofitError.java#L139).