### PR TITLE
Add removeTracksFromPlaylist by positions

### DIFF
--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
@@ -32,6 +32,7 @@ import kaaes.spotify.webapi.android.models.Track;
 import kaaes.spotify.webapi.android.models.Tracks;
 import kaaes.spotify.webapi.android.models.TracksPager;
 import kaaes.spotify.webapi.android.models.TracksToRemove;
+import kaaes.spotify.webapi.android.models.TracksToRemoveByPosition;
 import kaaes.spotify.webapi.android.models.TracksToRemoveWithPosition;
 import kaaes.spotify.webapi.android.models.UserPrivate;
 import kaaes.spotify.webapi.android.models.UserPublic;
@@ -407,6 +408,19 @@ public interface SpotifyService {
      */
     @DELETEWITHBODY("/users/{user_id}/playlists/{playlist_id}/tracks")
     void removeTracksFromPlaylist(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @Body TracksToRemoveWithPosition tracksToRemoveWithPosition, Callback<SnapshotId> callback);
+
+    /**
+     * Remove one or more tracks from a user’s playlist.
+     *
+     * @param userId                     The owner of the playlist
+     * @param playlistId                 The playlist's Id
+     * @param tracksToRemoveByPosition A list of positions of tracks to remove
+     * @param callback                   Callback method
+     * @see <a href="https://developer.spotify.com/web-api/remove-tracks-playlist/">Remove Tracks from a Playlist</a>
+     */
+    @DELETEWITHBODY("/users/{user_id}/playlists/{playlist_id}/tracks")
+    void removeTracksFromPlaylist(@Path("user_id") String userId, @Path("playlist_id") String playlistId, @Body TracksToRemoveByPosition tracksToRemoveByPosition, Callback<SnapshotId> callback);
+
 
     /**
      * Remove one or more tracks from a user’s playlist.

--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/TracksToRemoveByPosition.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/TracksToRemoveByPosition.java
@@ -1,0 +1,50 @@
+package kaaes.spotify.webapi.android.models;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Czarek on 2017-04-06.
+ */
+
+public class TracksToRemoveByPosition implements Parcelable {
+
+    public List<Integer> positions;
+    public String snapshot_id;
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeList(positions);
+        parcel.writeString(snapshot_id);
+    }
+
+    public TracksToRemoveByPosition() {
+    }
+
+    public TracksToRemoveByPosition(Parcel in){
+        this.positions = new ArrayList<>();
+        in.readList(this.positions, List.class.getClassLoader());
+        this.snapshot_id = in.readString();
+    }
+
+    public static final Parcelable.Creator<TracksToRemoveByPosition> CREATOR = new Parcelable.Creator<TracksToRemoveByPosition>(){
+
+        @Override
+        public TracksToRemoveByPosition createFromParcel(Parcel parcel) {
+            return new TracksToRemoveByPosition(parcel);
+        }
+
+        @Override
+        public TracksToRemoveByPosition[] newArray(int i) {
+            return new TracksToRemoveByPosition[i];
+        }
+    };
+}


### PR DESCRIPTION
The spotify api has been updated with a new way to remove tracks by positions by supplying an array of positions and a snapshot_Id. https://developer.spotify.com/web-api/remove-tracks-playlist/

This way you don't have to keep track of positions and uris at the same time and you get the added benefit of making sure that the request succeeds even under concurrent editing.