### PR TITLE
DW - changed new releases Pager to type Album.

### DIFF
--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/NewReleases.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/NewReleases.java
@@ -4,7 +4,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 public class NewReleases implements Parcelable {
-    public Pager<AlbumSimple> albums;
+    public Pager<Album> albums;
 
     @Override
     public int describeContents() {


### PR DESCRIPTION
The old implementation used an AlbumSimple which did not make use of all the data returned by the api call. 