### PR TITLE
add "After" Option to Spotify Service

### DIFF
--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
@@ -99,8 +99,8 @@ public interface SpotifyService {
     String TIME_RANGE = "time_range";
 
     /**
-    * Get User’s Followed Artists: The last artist ID retrieved from the previous request.
-    */
+     * Get User’s Followed Artists: The last artist ID retrieved from the previous request.
+     */
     String AFTER = "after";
 
     /************

--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
@@ -98,6 +98,10 @@ public interface SpotifyService {
 
     String TIME_RANGE = "time_range";
 
+    /**
+    * Get User’s Followed Artists: The last artist ID retrieved from the previous request.
+    */
+    String AFTER = "after";
 
     /************
      * Profiles *


### PR DESCRIPTION
This pull request adds the "AFTER" Option to the SpotifyService interface. The option is needed when getting the current user’s followed artists. See here: https://developer.spotify.com/web-api/get-followed-artists/
#162 