### PR TITLE
Added "Get Current User's Recently Played Tracks" endpoint

### DIFF
--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/SpotifyService.java
@@ -14,9 +14,12 @@ import kaaes.spotify.webapi.android.models.AudioFeaturesTrack;
 import kaaes.spotify.webapi.android.models.AudioFeaturesTracks;
 import kaaes.spotify.webapi.android.models.CategoriesPager;
 import kaaes.spotify.webapi.android.models.Category;
+import kaaes.spotify.webapi.android.models.ContextObject;
+import kaaes.spotify.webapi.android.models.CursorPager;
 import kaaes.spotify.webapi.android.models.FeaturedPlaylists;
 import kaaes.spotify.webapi.android.models.NewReleases;
 import kaaes.spotify.webapi.android.models.Pager;
+import kaaes.spotify.webapi.android.models.PlayHistory;
 import kaaes.spotify.webapi.android.models.Playlist;
 import kaaes.spotify.webapi.android.models.PlaylistFollowPrivacy;
 import kaaes.spotify.webapi.android.models.PlaylistSimple;
@@ -1810,4 +1813,48 @@ public interface SpotifyService {
     @GET("/me/top/tracks")
     void getTopTracks(@QueryMap Map<String, Object> options, Callback<Pager<Track>> callback);
 
+
+    /*****************************
+     * User's Recently Played Tracks *
+     *****************************/
+
+    /**
+     * Get tracks from the current user’s recently played tracks.
+     *
+     * @return A list of play history objects wrapped in a cursor-based paging object.
+     * The play history items each contain the context the track was played from (e.g. playlist, album),
+     * the date and time the track was played, and a track object (simplified).
+     */
+    @GET("/me/player/recently-played")
+    CursorPager<PlayHistory> getRecentlyPlayed();
+
+    /**
+     * Get tracks from the current user’s recently played tracks.
+     *
+     * @param callback callback method
+     */
+    @GET("/me/player/recently-played")
+    void getRecentlyPlayed(Callback<CursorPager<PlayHistory>> callback);
+
+    /**
+     * Get tracks from the current user’s recently played tracks.
+     *
+     * @param options Optional parameters. For list of available parameters see
+     *                <a href="https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played">endpoint documentation</a>
+     * @return A list of play history objects wrapped in a cursor-based paging object.
+     *      * The play history items each contain the context the track was played from (e.g. playlist, album),
+     *      * the date and time the track was played, and a track object (simplified).
+     */
+    @GET("/me/player/recently-played")
+    CursorPager<PlayHistory> getRecentlyPlayed(@QueryMap Map<String, Object> options);
+
+    /**
+     * Get tracks from the current user’s recently played tracks.
+     *
+     * @param options Optional parameters. For list of available parameters see
+     *                <a href="https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played">endpoint documentation</a>
+     * @param callback callback method
+     */
+    @GET("/me/player/recently-played")
+    void getRecentlyPlayed(@QueryMap Map<String, Object> options, Callback<CursorPager<PlayHistory>> callback);
 }

--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/ContextObject.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/ContextObject.java
@@ -1,0 +1,47 @@
+package kaaes.spotify.webapi.android.models;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import java.util.Map;
+
+public class ContextObject implements Parcelable {
+    public Map<String, String> external_urls;
+    public String href;
+    public String type;
+    public String uri;
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeMap(this.external_urls);
+        dest.writeString(this.href);
+        dest.writeString(this.type);
+        dest.writeString(this.uri);
+    }
+
+    public ContextObject(){
+
+    }
+
+    protected ContextObject(Parcel in){
+        this.external_urls = in.readHashMap(Map.class.getClassLoader());
+        this.href = in.readString();
+        this.type = in.readString();
+        this.uri = in.readString();
+    }
+
+    public static final Creator<ContextObject> CREATOR = new Creator<ContextObject>() {
+        public ContextObject createFromParcel(Parcel source) {
+            return new ContextObject(source);
+        }
+
+        public ContextObject[] newArray(int size) {
+            return new ContextObject[size];
+        }
+    };
+}

--- a/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlayHistory.java
+++ b/spotify-api/src/main/java/kaaes/spotify/webapi/android/models/PlayHistory.java
@@ -1,0 +1,42 @@
+package kaaes.spotify.webapi.android.models;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class PlayHistory implements Parcelable {
+    public ContextObject context;
+    public String playedAt;
+    public TrackSimple track;
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeParcelable(this.context, flags);
+        dest.writeString(this.playedAt);
+        dest.writeParcelable(this.track, flags);
+    }
+
+    public PlayHistory(){
+
+    }
+
+    protected PlayHistory(Parcel in){
+        this.context = in.readParcelable(ContextObject.class.getClassLoader());
+        this.playedAt = in.readString();
+        this.track = in.readParcelable(TrackSimple.class.getClassLoader());
+    }
+
+    public static final Creator<PlayHistory> CREATOR = new Creator<PlayHistory>() {
+        public PlayHistory createFromParcel(Parcel source) {
+            return new PlayHistory(source);
+        }
+
+        public PlayHistory[] newArray(int size) {
+            return new PlayHistory[size];
+        }
+    };
+}


### PR DESCRIPTION
Two new classes were created for this requirement: "ContextObject" and "PlayHistory". Both classes implement the interface Parcelable. I also added synchronous and asynchronous methods for Retrofit requests.

Attributes names taken from: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recently-played